### PR TITLE
feat(admin-service): add CRUD for clinic services with clinicId valid…

### DIFF
--- a/clinicsphere-backend/src/admin/admin-service.controller.ts
+++ b/clinicsphere-backend/src/admin/admin-service.controller.ts
@@ -1,0 +1,43 @@
+// src/admin-service/admin-service.controller.ts
+import {
+  Controller, Post, Body, Get, Query,
+  Param, Put, Delete, UseGuards
+} from '@nestjs/common';
+import { AdminServiceService } from './admin-service.service';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { UserRole } from 'src/users/user.schema';
+import { JwtAuthGuard } from 'src/auth/wt-auth.guard';
+import { CreateServiceDto } from './create-service.dto';
+
+@Controller('admin/admin-service')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+export class AdminServiceController {
+  constructor(private readonly serviceService: AdminServiceService) {}
+
+  @Post()
+  create(@Body() dto: CreateServiceDto) {
+    return this.serviceService.create(dto);
+  }
+
+  @Get()
+  findAll(@Query('clinicId') clinicId?: string) {
+    return this.serviceService.findAll(clinicId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.serviceService.findById(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: CreateServiceDto) {
+    return this.serviceService.update(id, dto);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.serviceService.delete(id);
+  }
+}

--- a/clinicsphere-backend/src/admin/admin-service.module.ts
+++ b/clinicsphere-backend/src/admin/admin-service.module.ts
@@ -1,0 +1,19 @@
+// src/admin-service/admin-service.module.ts
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { AdminServiceController } from './admin-service.controller';
+import { AdminServiceService } from './admin-service.service';
+import { AdminService, AdminServiceSchema } from './admin-service.schema';
+import { AdminClinic, AdminClinicSchema } from './admin-clinic.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: AdminService.name, schema: AdminServiceSchema },
+        { name: AdminClinic.name, schema: AdminClinicSchema },
+    ])
+  ],
+  controllers: [AdminServiceController],
+  providers: [AdminServiceService]
+})
+export class AdminServiceModule {}

--- a/clinicsphere-backend/src/admin/admin-service.schema.ts
+++ b/clinicsphere-backend/src/admin/admin-service.schema.ts
@@ -1,0 +1,31 @@
+// src/admin-service/schemas/admin-service.schema.ts
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document, Types } from 'mongoose';
+
+export type AdminServiceDocument = AdminService & Document;
+
+@Schema({ timestamps: true })
+export class AdminService {
+  @Prop({ required: true })
+  name: string;
+
+  @Prop()
+  description?: string;
+
+  @Prop({ required: true })
+  price: number;
+
+  @Prop({ required: true })
+  duration_minutes: number;
+
+  @Prop()
+  department?: string;
+
+  @Prop({ type: Types.ObjectId, ref: 'AdminClinic' })
+  clinicId?: Types.ObjectId;
+
+  @Prop({ default: 'active' })
+  status: 'active' | 'inactive';
+}
+
+export const AdminServiceSchema = SchemaFactory.createForClass(AdminService);

--- a/clinicsphere-backend/src/admin/admin-service.service.ts
+++ b/clinicsphere-backend/src/admin/admin-service.service.ts
@@ -1,0 +1,63 @@
+
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { AdminService, AdminServiceDocument } from './admin-service.schema';
+import { CreateServiceDto } from './create-service.dto';
+import { AdminClinic, ClinicDocument } from './admin-clinic.schema';
+@Injectable()
+export class AdminServiceService {
+    constructor(
+        @InjectModel(AdminService.name)
+        private readonly serviceModel: Model<AdminServiceDocument>,
+
+        @InjectModel(AdminClinic.name)
+        private readonly clinicModel: Model<ClinicDocument>
+    ) { }
+
+
+    async create(dto: CreateServiceDto): Promise<AdminService> {
+        if (dto.clinicId) {
+            if (!Types.ObjectId.isValid(dto.clinicId)) {
+                throw new BadRequestException('Invalid clinicId format');
+            }
+
+            const clinicExists = await this.clinicModel.exists({ _id: new Types.ObjectId(dto.clinicId) });
+            if (!clinicExists) {
+                throw new NotFoundException('Clinic not found');
+            }
+        }
+
+        return this.serviceModel.create(dto);
+    }
+
+    async findAll(clinicId?: string): Promise<AdminService[]> {
+        if (clinicId) {
+            return this.serviceModel.find({ clinicId }).exec();
+        }
+        return this.serviceModel.find().exec();
+    }
+
+    async findById(id: string): Promise<AdminService | null> {
+        return this.serviceModel.findById(id).exec();
+    }
+
+    async update(id: string, dto: CreateServiceDto): Promise<AdminService | null> {
+  if (dto.clinicId) {
+    if (!Types.ObjectId.isValid(dto.clinicId)) {
+      throw new BadRequestException('Invalid clinicId format');
+    }
+
+    const clinicExists = await this.clinicModel.exists({ _id: new Types.ObjectId(dto.clinicId) });
+    if (!clinicExists) {
+      throw new NotFoundException('Clinic not found');
+    }
+  }
+
+  return this.serviceModel.findByIdAndUpdate(id, dto, { new: true }).exec();
+}
+
+    async delete(id: string): Promise<AdminService | null> {
+        return this.serviceModel.findByIdAndDelete(id).exec();
+    }
+}

--- a/clinicsphere-backend/src/admin/create-service.dto.ts
+++ b/clinicsphere-backend/src/admin/create-service.dto.ts
@@ -1,0 +1,29 @@
+// src/admin-service/dto/create-service.dto.ts
+import { IsString, IsOptional, IsNumber, IsMongoId, IsEnum } from 'class-validator';
+
+export class CreateServiceDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsNumber()
+  price: number;
+
+  @IsNumber()
+  duration_minutes: number;
+
+  @IsOptional()
+  @IsString()
+  department?: string;
+
+  @IsOptional()
+  @IsMongoId()
+  clinicId?: string;
+
+  @IsOptional()
+  @IsEnum(['active', 'inactive'])
+  status?: 'active' | 'inactive';
+}

--- a/clinicsphere-backend/src/app.module.ts
+++ b/clinicsphere-backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { AppointmentsModule } from './appointments/appointments.module';
 import { ServeStaticModule } from '@nestjs/serve-static';
 import { join } from 'path';
 import { SpecialtiesModule } from './specialty/specialties.module';
+import { AdminServiceModule } from './admin/admin-service.module';
 
 @Module({
   imports: [
@@ -30,7 +31,8 @@ import { SpecialtiesModule } from './specialty/specialties.module';
     AdminModule,
     DoctorModule,
     AppointmentsModule,
-    SpecialtiesModule
+    SpecialtiesModule,
+    AdminServiceModule
   ],
   controllers: [AppController],
   providers: [AppService],


### PR DESCRIPTION
…ation

- Implemented full CRUD APIs for managing clinic services under /admin/admin-service
- Integrated clinicId reference with validation using Mongoose ObjectId
- Added guard clauses to prevent invalid or non-existent clinic references
- Registered AdminClinic schema for dependency injection into AdminServiceService
- Protected routes using JwtAuthGuard and RolesGuard (admin access only)