### PR TITLE
feat(service-category): implement admin CRUD API for service categories

### DIFF
--- a/clinicsphere-backend/src/admin/create-service-category.dto.ts
+++ b/clinicsphere-backend/src/admin/create-service-category.dto.ts
@@ -1,0 +1,14 @@
+import { IsString, IsOptional, IsEnum } from 'class-validator';
+
+export class CreateServiceCategoryDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsOptional()
+  @IsEnum(['active', 'inactive'])
+  status?: 'active' | 'inactive';
+}

--- a/clinicsphere-backend/src/admin/service-category.controller.ts
+++ b/clinicsphere-backend/src/admin/service-category.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller, Post, Get, Put, Delete,
+  Param, Body, UseGuards
+} from '@nestjs/common';
+import { ServiceCategoryService } from './service-category.service';
+import { RolesGuard } from '../auth/roles.guard';
+import { Roles } from '../auth/roles.decorator';
+import { JwtAuthGuard } from 'src/auth/wt-auth.guard';
+import { UserRole } from 'src/users/user.schema';
+import { CreateServiceCategoryDto } from './create-service-category.dto';
+
+@Controller('admin/service-category')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+export class ServiceCategoryController {
+  constructor(private readonly categoryService: ServiceCategoryService) {}
+
+  @Post()
+  create(@Body() dto: CreateServiceCategoryDto) {
+    return this.categoryService.create(dto);
+  }
+
+  @Get()
+  findAll() {
+    return this.categoryService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.categoryService.findById(id);
+  }
+
+  @Put(':id')
+  update(@Param('id') id: string, @Body() dto: CreateServiceCategoryDto) {
+    return this.categoryService.update(id, dto);
+  }
+
+  @Delete(':id')
+  delete(@Param('id') id: string) {
+    return this.categoryService.delete(id);
+  }
+}

--- a/clinicsphere-backend/src/admin/service-category.module.ts
+++ b/clinicsphere-backend/src/admin/service-category.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { MongooseModule } from '@nestjs/mongoose';
+import { ServiceCategoryController } from './service-category.controller';
+import { ServiceCategoryService } from './service-category.service';
+import { ServiceCategory, ServiceCategorySchema } from './service-category.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: ServiceCategory.name, schema: ServiceCategorySchema }
+    ])
+  ],
+  controllers: [ServiceCategoryController],
+  providers: [ServiceCategoryService]
+})
+export class ServiceCategoryModule {}

--- a/clinicsphere-backend/src/admin/service-category.schema.ts
+++ b/clinicsphere-backend/src/admin/service-category.schema.ts
@@ -1,0 +1,18 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Document } from 'mongoose';
+
+export type ServiceCategoryDocument = ServiceCategory & Document;
+
+@Schema({ timestamps: true })
+export class ServiceCategory {
+  @Prop({ required: true, unique: true })
+  name: string;
+
+  @Prop()
+  description?: string;
+
+  @Prop({ default: 'active' })
+  status: 'active' | 'inactive';
+}
+
+export const ServiceCategorySchema = SchemaFactory.createForClass(ServiceCategory);

--- a/clinicsphere-backend/src/admin/service-category.service.ts
+++ b/clinicsphere-backend/src/admin/service-category.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ServiceCategory, ServiceCategoryDocument } from './service-category.schema';
+import { CreateServiceCategoryDto } from './create-service-category.dto';
+
+@Injectable()
+export class ServiceCategoryService {
+  constructor(
+    @InjectModel(ServiceCategory.name)
+    private readonly categoryModel: Model<ServiceCategoryDocument>
+  ) {}
+
+  async create(dto: CreateServiceCategoryDto): Promise<ServiceCategory> {
+    return this.categoryModel.create(dto);
+  }
+
+  async findAll(): Promise<ServiceCategory[]> {
+    return this.categoryModel.find().exec();
+  }
+
+  async findById(id: string): Promise<ServiceCategory> {
+    const category = await this.categoryModel.findById(id);
+    if (!category) throw new NotFoundException('Category not found');
+    return category;
+  }
+
+  async update(id: string, dto: CreateServiceCategoryDto): Promise<ServiceCategory> {
+    const category = await this.categoryModel.findByIdAndUpdate(id, dto, { new: true });
+    if (!category) throw new NotFoundException('Category not found');
+    return category;
+  }
+
+  async delete(id: string): Promise<void> {
+    const result = await this.categoryModel.findByIdAndDelete(id);
+    if (!result) throw new NotFoundException('Category not found');
+  }
+}

--- a/clinicsphere-backend/src/app.module.ts
+++ b/clinicsphere-backend/src/app.module.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { SpecialtiesModule } from './specialty/specialties.module';
 import { AdminServiceModule } from './admin/admin-service.module';
 import { DoctorAssignmentModule } from './admin/doctor-assignment.module';
+import { ServiceCategoryModule } from './admin/service-category.module';
 
 @Module({
   imports: [
@@ -34,7 +35,8 @@ import { DoctorAssignmentModule } from './admin/doctor-assignment.module';
     AppointmentsModule,
     SpecialtiesModule,
     DoctorAssignmentModule,
-    AdminServiceModule
+    AdminServiceModule,
+    ServiceCategoryModule
   ],
   controllers: [AppController],
   providers: [AppService],


### PR DESCRIPTION
- Added ServiceCategory schema with name, description, and status fields
- Implemented Create, Read, Update, Delete endpoints under /admin/service-category
- Applied admin-only access using JwtAuthGuard and RolesGuard
- Added category validation and error handling for missing or invalid IDs
- Registered ServiceCategoryModule and integrated with Mongoose